### PR TITLE
Fix composer autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,9 @@
     "autoload": {
         "files": [
             "registration.php"
-        ]
+        ],
+        "psr-4": {
+            "ScandiPWA\\GtmGraphQl\\": ""
+        }
     }
 }


### PR DESCRIPTION
This PR fixes the error: `Class ScandiPWA\\GtmGraphQl\\Model\\Resolver\\GetGtm does not exist`